### PR TITLE
fix: runWithDelayedLoading

### DIFF
--- a/src/common.test.ts
+++ b/src/common.test.ts
@@ -805,6 +805,7 @@ describe("runWithDelayedLoading", () => {
 
     await vi.advanceTimersByTimeAsync(100) // Reach loadingDelay
     expect(onLoading).toBeCalledTimes(1)
+    expect(onSettled).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(200) // Task finishes (total 300ms)
     const isSettled1 = await Promise.race([
@@ -812,6 +813,7 @@ describe("runWithDelayedLoading", () => {
       Promise.resolve(false)
     ])
     expect(isSettled1).toBe(false) // promise should not settled
+    expect(onSettled).not.toHaveBeenCalled()
 
     // Should still wait additional 300ms to meet minLoadingDuration (500ms total)
     await vi.advanceTimersByTimeAsync(300)
@@ -874,6 +876,7 @@ describe("runWithDelayedLoading", () => {
 
     await vi.advanceTimersByTimeAsync(100) // Reach loadingDelay
     expect(onLoading).toBeCalledTimes(1)
+    expect(onSettled).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(200) // Task finishes (total 300ms)
     const isSettled1 = await Promise.race([

--- a/src/common.test.ts
+++ b/src/common.test.ts
@@ -736,6 +736,9 @@ describe('runWithTimeout', () => {
 })
 
 describe("runWithDelayedLoading", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
   it("should resolve immediately after delayed if task finishes before loadingDelay", async () => {
     vi.useFakeTimers()
 
@@ -750,14 +753,9 @@ describe("runWithDelayedLoading", () => {
     })
 
     await vi.advanceTimersByTimeAsync(50) // Task finishes before loadingDelay
-    // mockTask.mock.results[0].value.then(() => {}) // Resolve the task
-
-    // const result = await promise
-    // expect(result).toBe("result")
     expect(onLoading).not.toHaveBeenCalled()
     expect(onSettled).not.toHaveBeenCalled()
 
-    await vi.advanceTimersByTimeAsync(50) // Task finishes immediately after loadingDelay
     const result = await promise
     expect(result).toBe("result")
     expect(onLoading).not.toHaveBeenCalled()
@@ -808,11 +806,12 @@ describe("runWithDelayedLoading", () => {
     expect(onSettled).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(200) // Task finishes (total 300ms)
+
     const isSettled1 = await Promise.race([
       promise.then(() => true, () => true),
-      Promise.resolve(false)
+      Promise.resolve(false).then(r => r),
     ])
-    expect(isSettled1).toBe(false) // promise should not settled
+    expect(isSettled1).toBe(false) // promise should not settle
     expect(onSettled).not.toHaveBeenCalled()
 
     // Should still wait additional 300ms to meet minLoadingDuration (500ms total)
@@ -820,7 +819,7 @@ describe("runWithDelayedLoading", () => {
     expect(onSettled).toBeCalledTimes(1)
     const isSettled2 = await Promise.race([
       promise.then(() => true, () => true),
-      Promise.resolve(false)
+      Promise.resolve(false).then(r => r),
     ])
     const result = await promise
     expect(result).toBe("result")
@@ -881,15 +880,15 @@ describe("runWithDelayedLoading", () => {
     await vi.advanceTimersByTimeAsync(200) // Task finishes (total 300ms)
     const isSettled1 = await Promise.race([
       promise.then(() => true, () => true),
-      Promise.resolve(false)
+      Promise.resolve(false).then(r => r)
     ])
-    expect(isSettled1).toBe(false) // promise should not settled
+    expect(isSettled1).toBe(false) // promise should not settle
     expect(onSettled).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(300) // minLoadingDuration reached (500ms total)
     const isSettled2 = await Promise.race([
       promise.then(() => true, () => true),
-      Promise.resolve(false)
+      Promise.resolve(false).then(r => r)
     ])
     const result = await promise
     expect(result).toBe("result")

--- a/src/common.ts
+++ b/src/common.ts
@@ -1055,7 +1055,6 @@ export async function runWithDelayedLoading<T = any>(asyncTask: () => Promise<T>
   let loading = false // 是否展示loading中
   let settled = false // 异步任务是否完成
   // let resSettled = false // 返回的Promise是否已Settled
-  // let taskRes: T | Error | null = null // 异步任务返回的结果
   // let taskStartTime: number | null = null // 异步任务开始时间
   let loadingStartTime: number | null = null // 展示loading的开始时间
   // let loadingDelayTimeout = false // 是否超时时间
@@ -1080,7 +1079,6 @@ export async function runWithDelayedLoading<T = any>(asyncTask: () => Promise<T>
       resolve!(data)
       // resSettled = true
     } else {
-      // taskRes = data
     }
     return data
   }, (e) => {
@@ -1088,7 +1086,6 @@ export async function runWithDelayedLoading<T = any>(asyncTask: () => Promise<T>
       reject!(e)
       // resSettled = true
     } else {
-      // taskRes = e
     }
     return Promise.reject(e)
   }).finally(() => {


### PR DESCRIPTION
- runWithDelayedLoading 在异步任务先于 minLoadingDuration 完成时，返回的 Promis 不会等到加载结束才 Settled